### PR TITLE
Use testthat's new snapshot based testing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
+Config/testthat/edition: 3
 Imports: 
     shiny,
     jsonlite

--- a/tests/testthat/_snaps/fullscreen_all.md
+++ b/tests/testthat/_snaps/fullscreen_all.md
@@ -1,0 +1,8 @@
+# fullscreen_all produces the right JS
+
+    [1] "<script> $(function () { if (!screenfull.isEnabled) { return false; } $('#&lt;button id=\"click\" type=\"button\" class=\"btn btn-default action-button\"&gt;Click&lt;/button&gt;').click(function () { screenfull.request(); }); });</script><style>::backdrop { background-color:#fff; }</style>"
+
+# argument bg_color works
+
+    [1] "<script> $(function () { if (!screenfull.isEnabled) { return false; } $('#&lt;button id=\"click\" type=\"button\" class=\"btn btn-default action-button\"&gt;Click&lt;/button&gt;').click(function () { screenfull.request(); }); });</script><style>::backdrop { background-color:pink; }</style>"
+

--- a/tests/testthat/_snaps/fullscreen_this.md
+++ b/tests/testthat/_snaps/fullscreen_this.md
@@ -1,0 +1,12 @@
+# fullscreen_this produces the right JS
+
+    [1] "<div id=\"plot\" class=\"shiny-plot-output\" style=\"width: 100% ; height: 400px\"></div><script> $(function () { if (!screenfull.isEnabled) { return false; } $('#plot').click(function () { screenfull.request($('#plot')[0]); }); });</script><style>#plot{ cursor: -webkit-zoom-in; cursor: -moz-zoom-in; } ::backdrop { background-color:#fff; }</style>"
+
+# argument click_id works
+
+    [1] "<div id=\"plot\" class=\"shiny-plot-output\" style=\"width: 100% ; height: 400px\"></div><script> $(function () { if (!screenfull.isEnabled) { return false; } $('#other_id').click(function () { screenfull.request($('#plot')[0]); }); });</script><style>#plot{ cursor: -webkit-zoom-in; cursor: -moz-zoom-in; } ::backdrop { background-color:#fff; }</style>"
+
+# argument bg_color works
+
+    [1] "<div id=\"plot\" class=\"shiny-plot-output\" style=\"width: 100% ; height: 400px\"></div><script> $(function () { if (!screenfull.isEnabled) { return false; } $('#plot').click(function () { screenfull.request($('#plot')[0]); }); });</script><style>#plot{ cursor: -webkit-zoom-in; cursor: -moz-zoom-in; } ::backdrop { background-color:pink; }</style>"
+

--- a/tests/testthat/_snaps/fullscreen_those.md
+++ b/tests/testthat/_snaps/fullscreen_those.md
@@ -1,0 +1,8 @@
+# fullscreen_those works with 1 item
+
+    [1] "<script> var ids = [\"#plot\"]; $(ids.join(',')).click(function () { screenfull.request(this); });</script><style>#plot{ cursor: -webkit-zoom-in; cursor: -moz-zoom-in; } ::backdrop { background-color:#fff; }</style>"
+
+# fullscreen_those works with several items
+
+    [1] "<script> var ids = [\"#plot\",\"#plot2\"]; $(ids.join(',')).click(function () { screenfull.request(this); });</script><style>#plot, #plot2{ cursor: -webkit-zoom-in; cursor: -moz-zoom-in; } ::backdrop { background-color:#fff; }</style>"
+

--- a/tests/testthat/test-fullscreen_all.R
+++ b/tests/testthat/test-fullscreen_all.R
@@ -3,37 +3,24 @@ test_that("fullscreen_all needs a click_id argument", {
 })
 
 test_that("fullscreen_all produces the right JS", {
-  x <- shiny::actionButton("click", "Click")
-
-  y <- x %>%
+  shiny::actionButton("click", "Click") %>%
     fullscreen_all() %>%
     paste() %>%
     gsub("\\t", "", .) %>%
     gsub("\\n", "", .) %>%
     # remove additional spaces
-    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE)
-
-  expect_equal(
-    y,
-    "<script> $(function () { if (!screenfull.isEnabled) { return false; } $('#&lt;button id=\"click\" type=\"button\" class=\"btn btn-default action-button\"&gt;Click&lt;/button&gt;').click(function () { screenfull.request(); }); });</script><style>::backdrop { background-color:#fff; }</style>"
-  )
-
+    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE) %>%
+    expect_snapshot_output()
 })
 
 test_that("argument bg_color works", {
-  x <- shiny::actionButton("click", "Click")
 
-  y <- x %>%
+  shiny::actionButton("click", "Click") %>%
     fullscreen_all(bg_color = "pink") %>%
     paste() %>%
     gsub("\\t", "", .) %>%
     gsub("\\n", "", .) %>%
     # remove additional spaces
-    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE)
-
-  expect_equal(
-    y,
-    "<script> $(function () { if (!screenfull.isEnabled) { return false; } $('#&lt;button id=\"click\" type=\"button\" class=\"btn btn-default action-button\"&gt;Click&lt;/button&gt;').click(function () { screenfull.request(); }); });</script><style>::backdrop { background-color:pink; }</style>"
-  )
-
+    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE) %>%
+    expect_snapshot_output()
 })

--- a/tests/testthat/test-fullscreen_this.R
+++ b/tests/testthat/test-fullscreen_this.R
@@ -4,51 +4,34 @@ test_that("fullscreen_this throws an error if no ui_element", {
 
 
 test_that("fullscreen_this produces the right JS", {
-  x <- shiny::plotOutput("plot") %>%
+  shiny::plotOutput("plot") %>%
     fullscreen_this() %>%
     paste() %>%
     gsub("\\t", "", .) %>%
     gsub("\\n", "", .) %>%
     # remove additional spaces
-    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE)
-
-  expect_equal(
-    x,
-    "<div id=\"plot\" class=\"shiny-plot-output\" style=\"width: 100% ; height: 400px\"></div><script> $(function () { if (!screenfull.isEnabled) { return false; } $('#plot').click(function () { screenfull.request($('#plot')[0]); }); });</script><style>#plot{ cursor: -webkit-zoom-in; cursor: -moz-zoom-in; } ::backdrop { background-color:#fff; }</style>"
-  )
-
+    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE) %>%
+    expect_snapshot_output()
 })
 
 test_that("argument click_id works", {
-
-  x <- shiny::plotOutput("plot") %>%
+  shiny::plotOutput("plot") %>%
     fullscreen_this(click_id = "other_id") %>%
     paste() %>%
     gsub("\\t", "", .) %>%
     gsub("\\n", "", .) %>%
     # remove additional spaces
-    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE)
-
-  expect_equal(
-    x,
-    "<div id=\"plot\" class=\"shiny-plot-output\" style=\"width: 100% ; height: 400px\"></div><script> $(function () { if (!screenfull.isEnabled) { return false; } $('#other_id').click(function () { screenfull.request($('#plot')[0]); }); });</script><style>#plot{ cursor: -webkit-zoom-in; cursor: -moz-zoom-in; } ::backdrop { background-color:#fff; }</style>"
-  )
-
+    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE) %>%
+    expect_snapshot_output()
 })
 
 test_that("argument bg_color works", {
-
-  x <- shiny::plotOutput("plot") %>%
+  shiny::plotOutput("plot") %>%
     fullscreen_this(bg_color = "pink") %>%
     paste() %>%
     gsub("\\t", "", .) %>%
     gsub("\\n", "", .) %>%
     # remove additional spaces
-    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE)
-
-  expect_equal(
-    x,
-    "<div id=\"plot\" class=\"shiny-plot-output\" style=\"width: 100% ; height: 400px\"></div><script> $(function () { if (!screenfull.isEnabled) { return false; } $('#plot').click(function () { screenfull.request($('#plot')[0]); }); });</script><style>#plot{ cursor: -webkit-zoom-in; cursor: -moz-zoom-in; } ::backdrop { background-color:pink; }</style>"
-  )
-
+    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE) %>%
+    expect_snapshot_output()
 })

--- a/tests/testthat/test-fullscreen_those.R
+++ b/tests/testthat/test-fullscreen_those.R
@@ -15,17 +15,13 @@ test_that("fullscreen_those works with 1 item", {
 
   plot1 <- shiny::plotOutput("plot")
 
-  x <- fullscreen_those(items = list("plot")) %>%
+  fullscreen_those(items = list("plot")) %>%
     paste() %>%
     gsub("\\t", "", .) %>%
     gsub("\\n", "", .) %>%
     # remove additional spaces
-    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE)
-
-  expect_equal(
-    x,
-    "<script> var ids = [\"#plot\"]; $(ids.join(',')).click(function () { screenfull.request(this); });</script><style>#plot{ cursor: -webkit-zoom-in; cursor: -moz-zoom-in; } ::backdrop { background-color:#fff; }</style>"
-  )
+    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE) %>%
+    expect_snapshot_output()
 
 })
 
@@ -34,16 +30,12 @@ test_that("fullscreen_those works with several items", {
   plot1 <- shiny::plotOutput("plot")
   plot2 <- shiny::plotOutput("plot2")
 
-  x <- fullscreen_those(items = list("plot", "plot2")) %>%
+  fullscreen_those(items = list("plot", "plot2")) %>%
     paste() %>%
     gsub("\\t", "", .) %>%
     gsub("\\n", "", .) %>%
     # remove additional spaces
-    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE)
-
-  expect_equal(
-    x,
-    "<script> var ids = [\"#plot\",\"#plot2\"]; $(ids.join(',')).click(function () { screenfull.request(this); });</script><style>#plot, #plot2{ cursor: -webkit-zoom-in; cursor: -moz-zoom-in; } ::backdrop { background-color:#fff; }</style>"
-  )
+    gsub("(?<=[\\s])\\s*|^\\s+|\\s+$", "", ., perl = TRUE) %>%
+    expect_snapshot_output()
 
 })


### PR DESCRIPTION
In the next version of shiny (which we plan on submitting to CRAN in a week or so), we've made several changes to HTML/CSS markup which causes your unit tests to fail (in non-meaningful ways), and so we ask you to submit a new version of shinyfullscreen to CRAN as soon as possible to address this issue.

This PR fixes the problem by updating your test expectations to use the new `testthat::expect_snapshot_output()` which provides a much better experience with "snapshot-based testing" and also follows best practices of disabling these tests on CRAN.  This way, you'll still be notified of any changes through local or CI-based testing, but it we can continue to make HTML/CSS changes to shiny without requiring another release of shinyfullscreen.

Please let me know if you have any questions and send a new version of shinyfullscreen to CRAN with these updates to your test expectations as soon as possible.